### PR TITLE
fix(crud): regex instead of $text for generic getPage search

### DIFF
--- a/lib/src/main/kotlin/nl/asrr/core/generics/search/FreeTextSearch.kt
+++ b/lib/src/main/kotlin/nl/asrr/core/generics/search/FreeTextSearch.kt
@@ -1,0 +1,60 @@
+/* Copyright 2017-2026 ASRR B.V. */
+package nl.asrr.core.generics.search
+
+import org.springframework.data.mongodb.core.query.Criteria
+import java.util.concurrent.ConcurrentHashMap
+import java.util.regex.Pattern
+
+/**
+ * Builds a Mongo criteria for the generic free-text `?search=` used by the CRUD `getPage` endpoint.
+ *
+ * The CRUD services previously searched via [org.springframework.data.mongodb.core.query.TextCriteria],
+ * which emits a MongoDB `$text` query. `$text` requires a text index on the collection; entities that
+ * declare none fail at runtime with Mongo error 27 `IndexNotFound: 'text index required for $text
+ * query'`, surfacing as an unhandled exception → HTTP 500 on any search.
+ *
+ * A per-field, case-insensitive regex needs no index: every whitespace-separated word must appear
+ * within a single field (AND within a field), OR-ed across fields.
+ */
+object FreeTextSearch {
+    private val searchableFieldsCache = ConcurrentHashMap<Class<*>, List<String>>()
+    private val WHITESPACE = "\\s+".toRegex()
+
+    /**
+     * Regex criteria matching [search] against the entity's human-text String fields, or `null` when
+     * there is nothing to search (blank input or the entity exposes no searchable text field) — in
+     * which case the caller should apply no text filter.
+     */
+    fun criteria(search: String, entityClass: Class<*>): Criteria? {
+        if (search.isBlank()) return null
+        val words = search.trim().split(WHITESPACE).filter { it.isNotBlank() }
+        if (words.isEmpty()) return null
+
+        val fields = searchableFields(entityClass)
+        if (fields.isEmpty()) return null
+
+        val pattern =
+            Pattern.compile(
+                words.joinToString("") { "(?=.*${Pattern.quote(it)})" } + ".*",
+                Pattern.CASE_INSENSITIVE,
+            )
+        val perField = fields.map { Criteria(it).regex(pattern) }
+        return if (perField.size == 1) perField.first() else Criteria().orOperator(*perField.toTypedArray())
+    }
+
+    /**
+     * The String fields worth searching: the entity's own text fields, excluding identity (`id`),
+     * foreign-key references (`*Id`, e.g. customerId/ownerId) and audit fields (`*By`, e.g. createdBy).
+     * Those hold opaque values that never match a human search term and only widen the query.
+     */
+    private fun searchableFields(entityClass: Class<*>): List<String> =
+        searchableFieldsCache.getOrPut(entityClass) {
+            generateSequence(entityClass) { it.superclass }
+                .flatMap { it.declaredFields.asSequence() }
+                .filter { it.type == String::class.java && !it.isSynthetic }
+                .map { it.name }
+                .filter { it != "id" && !it.endsWith("Id") && !it.endsWith("By") }
+                .distinct()
+                .toList()
+        }
+}

--- a/lib/src/main/kotlin/nl/asrr/core/generics/service/ICrudService.kt
+++ b/lib/src/main/kotlin/nl/asrr/core/generics/service/ICrudService.kt
@@ -6,7 +6,9 @@ import nl.asrr.core.exceptions.NotFoundException
 import nl.asrr.core.generics.model.ICrudEntity
 import nl.asrr.core.generics.model.IEntitySearch
 import nl.asrr.core.generics.repository.ICrudRepository
+import nl.asrr.core.generics.search.FreeTextSearch
 import org.springframework.beans.support.PagedListHolder
+import org.springframework.core.GenericTypeResolver
 import org.springframework.data.domain.Example
 import org.springframework.data.domain.ExampleMatcher
 import org.springframework.data.domain.Page
@@ -17,7 +19,6 @@ import org.springframework.data.domain.Sort
 import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.data.mongodb.core.query.Criteria
 import org.springframework.data.mongodb.core.query.Query
-import org.springframework.data.mongodb.core.query.TextCriteria
 import org.springframework.data.mongodb.core.query.UntypedExampleMatcher
 import java.time.ZonedDateTime
 
@@ -66,9 +67,26 @@ abstract class ICrudService<T>(
             return repository.findAll(pageable)
         }
 
-        val criteria = TextCriteria().matchingAny(search)
+        // A $text query (TextCriteria) requires a collection text index; entities that declare none
+        // fail with Mongo error 27 → HTTP 500 on any search. Match with a per-field regex instead
+        // (see FreeTextSearch), which needs no index. Fall back to the unfiltered page when the entity
+        // type can't be resolved or has no searchable field — never a 500.
+        val entityClass = resolvedEntityClass
+        val searchCriteria = entityClass?.let { FreeTextSearch.criteria(search, it) }
+            ?: return repository.findAll(pageable)
 
-        return repository.findAllBy(criteria, pageable)
+        val query = Query(searchCriteria)
+        val total = mongoTemplate.count(Query.of(query), entityClass)
+        query.with(pageable)
+
+        @Suppress("UNCHECKED_CAST")
+        val content = mongoTemplate.find(query, entityClass) as List<T>
+        return PageImpl(content, pageable, total)
+    }
+
+    /** The concrete entity type behind `T`, resolved once per instance (null if it can't be inferred). */
+    protected val resolvedEntityClass: Class<*>? by lazy {
+        GenericTypeResolver.resolveTypeArgument(javaClass, ICrudService::class.java)
     }
 
     inline fun <reified T : Any> search(

--- a/lib/src/main/kotlin/nl/asrr/core/generics/service/ITenantCrudService.kt
+++ b/lib/src/main/kotlin/nl/asrr/core/generics/service/ITenantCrudService.kt
@@ -5,10 +5,14 @@ import nl.asrr.core.auth.service.ISecurityService
 import nl.asrr.core.exceptions.NotFoundException
 import nl.asrr.core.generics.model.ITenantCrudEntity
 import nl.asrr.core.generics.repository.ITenantCrudRepository
+import nl.asrr.core.generics.search.FreeTextSearch
 import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.data.mongodb.core.MongoTemplate
-import org.springframework.data.mongodb.core.query.TextCriteria
+import org.springframework.data.mongodb.core.query.Criteria
+import org.springframework.data.mongodb.core.query.Criteria.where
+import org.springframework.data.mongodb.core.query.Query
 
 abstract class ITenantCrudService<T : ITenantCrudEntity>(
     override val repository: ITenantCrudRepository<T>,
@@ -32,9 +36,21 @@ abstract class ITenantCrudService<T : ITenantCrudEntity>(
             return repository.findAllByTenantId(tenantId, pageable)
         }
 
-        val criteria = TextCriteria().matchingAny(search)
+        // A $text query (TextCriteria) requires a collection text index; entities that declare none
+        // fail with Mongo error 27 → HTTP 500 on any search. Match with a per-field regex instead
+        // (see FreeTextSearch), which needs no index. Fall back to the unfiltered tenant page when the
+        // entity type can't be resolved or has no searchable field — never a 500.
+        val entityClass = resolvedEntityClass
+        val searchCriteria = entityClass?.let { FreeTextSearch.criteria(search, it) }
+            ?: return repository.findAllByTenantId(tenantId, pageable)
 
-        return repository.findAllByTenantId(tenantId, criteria, pageable)
+        val query = Query(Criteria().andOperator(where("tenantId").`is`(tenantId), searchCriteria))
+        val total = mongoTemplate.count(Query.of(query), entityClass)
+        query.with(pageable)
+
+        @Suppress("UNCHECKED_CAST")
+        val content = mongoTemplate.find(query, entityClass) as List<T>
+        return PageImpl(content, pageable, total)
     }
 
     override fun findAll(): List<T> {

--- a/lib/src/test/kotlin/nl/asrr/core/generics/search/FreeTextSearchTest.kt
+++ b/lib/src/test/kotlin/nl/asrr/core/generics/search/FreeTextSearchTest.kt
@@ -1,0 +1,72 @@
+/* Copyright 2017-2026 ASRR B.V. */
+package nl.asrr.core.generics.search
+
+import org.bson.Document
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.regex.Pattern
+
+class FreeTextSearchTest {
+
+    // A stand-in entity with the field shapes the reflection rule has to handle: human-text fields,
+    // a foreign-key ref (*Id), an audit field (*By), the identity field, and a non-String field.
+    @Suppress("unused")
+    private class SampleEntity(
+        val id: String,
+        val tenantId: String,
+        val number: String,
+        val name: String,
+        val description: String?,
+        val customerId: String,
+        val createdBy: String,
+        val value: Double?,
+    )
+
+    private fun keysDeep(doc: Document): Set<String> = buildSet {
+        doc.forEach { (k, v) ->
+            add(k)
+            when (v) {
+                is Document -> addAll(keysDeep(v))
+                is List<*> -> v.filterIsInstance<Document>().forEach { addAll(keysDeep(it)) }
+            }
+        }
+    }
+
+    @Test
+    fun `blank search yields no criteria`() {
+        assertNull(FreeTextSearch.criteria("", SampleEntity::class.java))
+        assertNull(FreeTextSearch.criteria("   ", SampleEntity::class.java))
+    }
+
+    @Test
+    fun `search never emits a text query and matches each field with a regex Pattern`() {
+        val doc = FreeTextSearch.criteria("kitchen", SampleEntity::class.java)!!.criteriaObject
+        assertFalse(keysDeep(doc).contains("\$text"), "must not use \$text (needs a text index that doesn't exist)")
+        val clauses = (doc["\$or"] as List<*>).filterIsInstance<Document>()
+        assertTrue(clauses.isNotEmpty())
+        clauses.forEach { clause ->
+            val value = clause.values.first()
+            assertTrue(value is Pattern, "field ${clause.keys.first()} should match via regex, was ${value?.javaClass}")
+            assertTrue((value as Pattern).flags() and Pattern.CASE_INSENSITIVE != 0, "regex should be case-insensitive")
+        }
+    }
+
+    @Test
+    fun `only human-text fields are searched, not id foreign-key or audit fields`() {
+        val doc = FreeTextSearch.criteria("kitchen", SampleEntity::class.java)!!.criteriaObject
+        val fields = (doc["\$or"] as List<*>).filterIsInstance<Document>().flatMap { it.keys }.toSet()
+        assertEquals(setOf("number", "name", "description"), fields)
+    }
+
+    @Test
+    fun `each word must appear within a single field (AND within field)`() {
+        val doc = FreeTextSearch.criteria("walk in shower", SampleEntity::class.java)!!.criteriaObject
+        val regex = (((doc["\$or"] as List<*>).first() as Document).values.first() as Pattern).pattern()
+        listOf("walk", "in", "shower").forEach { word ->
+            assertTrue(regex.contains("(?=.*${Pattern.quote(word)})"), "expected lookahead for '$word' in: $regex")
+        }
+    }
+}


### PR DESCRIPTION
## Why

The generic CRUD `find(pageable, search)` (the `getPage?search=` endpoint) built a MongoDB `$text` query via `TextCriteria`. `$text` requires a **collection text index**; entities that declare none fail at runtime with Mongo **error 27 `IndexNotFound: 'text index required for $text query'`** → unhandled exception → **HTTP 500 on any search**.

This bit Alpha in production: the CRM opportunity list produced a burst of 500s (alpha-prod, 2026-07-07). Alpha patched its own `IAlphaCrudService`/`SubsidiaryAccessGuard` (alpha PR #621), but ~10 services extend **core** `ITenantCrudService` directly (SentMail, Favorite, Subsidiary, Event, Notification, Type, Texture, MaterialTextureMapping, AssetLocation, AssetInstance) and still inherit this core `$text` path. This PR fixes it at the source.

## Fix

New `FreeTextSearch` — a per-field, case-insensitive **regex** builder that needs no index: every whitespace-separated word must appear within a single field (AND within a field), OR-ed across fields. It searches the entity's own String fields, excluding identity (`id`), foreign keys (`*Id`) and audit fields (`*By`).

The concrete entity type is resolved once per instance via Spring `GenericTypeResolver`. When it can't be resolved or the entity has no searchable field, it falls back to the unfiltered page — **never a 500**.

Applied to both `ITenantCrudService.find` (tenant-scoped) and `ICrudService.find`.

## Tests

`FreeTextSearchTest` pins: no `$text` emitted, case-insensitive regex Patterns, only human-text fields searched (excludes `id`/`*Id`/`*By`), AND-of-words semantics. Full `./gradlew build` green.

## Release / rollout

- Merging to `dev` triggers semantic-release → **Maven Central publish** as a patch (**1.2.2**, independent of the pending cookie-auth 1.3.0 `feat`).
- After publish, bump Alpha's `nl.asrr:core` (currently `1.2.0`) to pick it up. Alpha's own `FreeTextSearch` can later be dropped in favour of core's, but that's optional cleanup — the two are compatible.

https://claude.ai/code/session_01Q2KLv8FDYUKi7msbzuCM8B